### PR TITLE
IGame and IDisplay decoupling

### DIFF
--- a/include/arcade/IAssetManager.hpp
+++ b/include/arcade/IAssetManager.hpp
@@ -1,0 +1,66 @@
+/*
+** EPITECH PROJECT, 2022
+** Arcade: Interface
+** File description:
+** Creation of Assets and Game objects
+*/
+
+/// @file
+///
+/// Creation of Assets and Game Objects.
+
+#ifndef ARCADE_IASSET_MANAGER_HPP_
+#define ARCADE_IASSET_MANAGER_HPP_
+
+#include <memory>
+#include <string_view>
+
+#include "IAsset.hpp"
+#include "types.hpp"
+
+namespace arcade
+{
+    class IGameObject;
+
+    /// Loads assets and creates game objects.
+    class IAssetManager {
+      public:
+        virtual ~IAssetManager() = default;
+
+        /// Fetches an asset by name, loading it if necessary.
+        ///
+        /// The returned IAsset instance is a reference to the real underlying asset, when switching displays, all
+        /// existing instances of IAsset will attempt to convert to equivalent assets for the new display mode.
+        ///
+        /// @param name The name of the requested asset.
+        /// @param type Which type of asset to fetch?
+        ///
+        /// @returns A reference to the loaded asset, or a null reference if the requested asset failed to load.
+        virtual std::unique_ptr<IAsset> loadAsset(std::string_view name, IAsset::Type type) = 0;
+
+        /// Creates a text (as in string) object instance.
+        ///
+        /// @param text The string to display.
+        /// @param font The font to use. If @c nullptr, the font isn't used.
+        ///
+        /// @throws std::logic_error When @c font is not a font asset.
+        /// @throws std::logic_error When @c font is @c nulltptr and a TextObject can't be created without a font.
+        ///
+        /// @returns A boxed IGameObject instance.
+        virtual std::unique_ptr<IGameObject> createTextObject(
+            std::string_view text, IAsset const *font = nullptr) const = 0;
+
+        /// Creates a textured rectangle object.
+        ///
+        /// @param size The dimensions (in units) of the rectangle.
+        /// @param texture The texture to use. If @c nullptr, the texture isn't used.
+        ///
+        /// @throws std::logic_error When @c texture is not a texture asset.
+        /// @throws std::logic_error When @c texture is @c nullptr and a RectObject can't be created without a texture.
+        ///
+        /// @returns A boxed IGameObject instance.
+        virtual std::unique_ptr<IGameObject> createRectObject(vec2u size, IAsset const *texture = nullptr) const = 0;
+    };
+} // namespace arcade
+
+#endif /* !ARCADE_IASSET_MANAGER_HPP_ */

--- a/include/arcade/IGame.hpp
+++ b/include/arcade/IGame.hpp
@@ -19,8 +19,9 @@
 
 namespace arcade
 {
-    class IDisplay;
     struct Event;
+    class IAssetManager;
+    class IRenderer;
 
     /// A game instance.
     class IGame {
@@ -53,7 +54,14 @@ namespace arcade
         /// @note Calling this method without calling IGame::setup() leads to <b>undefined behavior</b>.
         ///
         /// @param display The starting display manager.
-        virtual void setup(IDisplay &display) = 0;
+        virtual void setup() = 0;
+
+        /// (Re)-loads assets and game objects.
+        ///
+        /// This method is called each time the underlying graphics backend is switched.
+        ///
+        /// @param manager The assets manager.
+        virtual void loadAssets(IAssetManager &manager) = 0;
 
         /// Releases the ressources allocated by this game.
         ///
@@ -62,15 +70,6 @@ namespace arcade
         ///
         /// @note Calling this method without calling IGame::setup() leads to <b>undefined behavior</b>.
         virtual void close() = 0;
-
-        /// Changes the display of the game.
-        ///
-        /// Changes in display must not interrupt the game.
-        ///
-        /// @note Calling this method without calling IGame::setup() leads to <b>undefined behavior</b>.
-        ///
-        /// @param display The new display manager.
-        virtual void setDisplay(IDisplay &display) = 0;
 
         /// Alters the state of the game.
         ///
@@ -99,7 +98,9 @@ namespace arcade
         /// Draw the game GameObjects.
         ///
         /// @note Calling this method without calling IGame::setup() leads to <b>undefined behavior</b>.
-        virtual void draw() = 0;
+        ///
+        /// @param renderer The renderer.
+        virtual void render(IRenderer &renderer) = 0;
 
         /// Handles the given event.
         ///

--- a/include/arcade/IRenderer.hpp
+++ b/include/arcade/IRenderer.hpp
@@ -1,0 +1,33 @@
+/*
+** EPITECH PROJECT, 2022
+** Arcade: Interface
+** File description:
+** Game rendering
+*/
+
+/// @file
+///
+/// Game rendering.
+
+#ifndef ARCADE_IRENDERER_HPP_
+#define ARCADE_IRENDERER_HPP_
+
+namespace arcade
+{
+    class IGameObject;
+
+    /// Rendering interface.
+    class IRenderer {
+      public:
+        virtual ~IRenderer() = default;
+
+        /// Draws a game object to the display's internal buffer(s).
+        ///
+        /// Drawn IGameObject instances will not display until the next call to IDisplay::render().
+        ///
+        /// @param object The object to draw.
+        virtual void draw(IGameObject const &object) = 0;
+    };
+} // namespace arcade
+
+#endif // !defined(ARCADE_IRENDERER_HPP_)


### PR DESCRIPTION
Remove all direct references to `IDisplay` in `IGame`.

`IGame` implementations now use the new `IRenderer` and `IAssetManager` interfaces.