### PR TITLE
[ADD] displaySize parameter to loadAsset

### DIFF
--- a/include/arcade/IGame.hpp
+++ b/include/arcade/IGame.hpp
@@ -20,6 +20,7 @@
 namespace arcade
 {
     struct Event;
+    struct vec2u;
     class IAssetManager;
     class IRenderer;
 
@@ -61,7 +62,8 @@ namespace arcade
         /// This method is called each time the underlying graphics backend is switched.
         ///
         /// @param manager The assets manager.
-        virtual void loadAssets(IAssetManager &manager) = 0;
+        /// @param displaySize The size of the display.
+        virtual void loadAssets(IAssetManager &manager, vec2u displaySize) = 0;
 
         /// Releases the ressources allocated by this game.
         ///

--- a/include/arcade/IGame.hpp
+++ b/include/arcade/IGame.hpp
@@ -63,7 +63,7 @@ namespace arcade
         ///
         /// @param manager The assets manager.
         /// @param displaySize The size of the display.
-        virtual void loadAssets(IAssetManager &manager, const vec2u displaySize) = 0;
+        virtual void loadAssets(IAssetManager &manager, vec2u displaySize) = 0;
 
         /// Releases the ressources allocated by this game.
         ///

--- a/include/arcade/IGame.hpp
+++ b/include/arcade/IGame.hpp
@@ -16,11 +16,11 @@
 #define ARCADE_GAME_ENTRY_POINT extern "C" ::arcade::IGame *arcade_GameEntryPoint()
 
 #include <string_view>
+#include "types.hpp"
 
 namespace arcade
 {
     struct Event;
-    struct vec2u;
     class IAssetManager;
     class IRenderer;
 

--- a/include/arcade/IGame.hpp
+++ b/include/arcade/IGame.hpp
@@ -15,8 +15,8 @@
 /// Entry point to get an instance of IGame
 #define ARCADE_GAME_ENTRY_POINT extern "C" ::arcade::IGame *arcade_GameEntryPoint()
 
-#include <string_view>
 #include "types.hpp"
+#include <string_view>
 
 namespace arcade
 {

--- a/include/arcade/IGame.hpp
+++ b/include/arcade/IGame.hpp
@@ -63,7 +63,7 @@ namespace arcade
         ///
         /// @param manager The assets manager.
         /// @param displaySize The size of the display.
-        virtual void loadAssets(IAssetManager &manager, vec2u displaySize) = 0;
+        virtual void loadAssets(IAssetManager &manager, vec2u &displaySize) = 0;
 
         /// Releases the ressources allocated by this game.
         ///

--- a/include/arcade/IGame.hpp
+++ b/include/arcade/IGame.hpp
@@ -63,7 +63,7 @@ namespace arcade
         ///
         /// @param manager The assets manager.
         /// @param displaySize The size of the display.
-        virtual void loadAssets(IAssetManager &manager, vec2u &displaySize) = 0;
+        virtual void loadAssets(IAssetManager &manager, const vec2u displaySize) = 0;
 
         /// Releases the ressources allocated by this game.
         ///


### PR DESCRIPTION
To have the display Size at the initialization of each game.

Actually, we can handle resizing events in game but we don't have the initial size to initialize each game.
Sending the display size in loadAssets would allow us this